### PR TITLE
RedisStorage: prevents clean and write concurrency

### DIFF
--- a/src/Kdyby/Redis/RedisStorage.php
+++ b/src/Kdyby/Redis/RedisStorage.php
@@ -16,7 +16,6 @@ use Nette\Caching\Cache;
 use Nette\Caching\Storages\IJournal;
 
 
-
 /**
  * Redis Storage.
  *
@@ -219,12 +218,9 @@ class RedisStorage extends Nette\Object implements IMultiReadStorage
 		}
 
 		$cacheKey = $this->formatEntryKey($key);
-
-		if (isset($dp[Cache::TAGS]) || isset($dp[Cache::PRIORITY])) {
-			if (!$this->journal) {
-				throw new Nette\InvalidStateException('CacheJournal has not been provided.');
-			}
-			$this->journal->write($cacheKey, $dp);
+		$useJournal = isset($dp[Cache::TAGS]) || isset($dp[Cache::PRIORITY]);
+		if ($useJournal && !$this->journal) { // fail early
+			throw new Nette\InvalidStateException('CacheJournal has not been provided.');
 		}
 
 		if (!is_string($data) || $data === NULL) {
@@ -247,6 +243,15 @@ class RedisStorage extends Nette\Object implements IMultiReadStorage
 		} catch (RedisClientException $e) {
 			$this->remove($key);
 			throw new Nette\InvalidStateException($e->getMessage(), $e->getCode(), $e);
+		}
+
+		if ($useJournal) {
+			try {
+				$this->journal->write($cacheKey, $dp);
+			} catch (\Throwable $e) {
+				$this->remove($key);
+				throw $e;
+			}
 		}
 	}
 


### PR DESCRIPTION
there was a multiple job concurrency in RedisStorage::write
 - storage writes tags to journal
 - another process cleans those tags
 - storage writes data

as result there were data saved in cache but tags in journal were missing
 - those records will never invalidate

solved by switching tags/data write order