### PR TITLE
Redis journal lock + lock with TTL

### DIFF
--- a/src/Kdyby/Redis/RedisClient.php
+++ b/src/Kdyby/Redis/RedisClient.php
@@ -158,9 +158,22 @@ class RedisClient extends Nette\Object implements \ArrayAccess
 {
 
 	/** @deprecated */
-	const WITH_SCORES = 'WITHSCORES';
+	public const WITH_SCORES = 'WITHSCORES';
 
-	const DEFAULT_PORT = 6379;
+	public const DEFAULT_PORT = 6379;
+
+	/**
+	 * Set the specified expire time, in milliseconds.
+	 */
+	public const PX = 'PX';
+	/**
+	 * Set the specified expire time, in seconds.
+	 */
+	public const EX = 'EX';
+	/**
+	 * Option - Only set the key if it does not already exist.
+	 */
+	public const NX = 'NX';
 
 	/**
 	 * @var Driver\PhpRedisDriver

--- a/src/Kdyby/Redis/RedisJournal.php
+++ b/src/Kdyby/Redis/RedisJournal.php
@@ -181,9 +181,21 @@ class RedisJournal extends Nette\Object implements Nette\Caching\Storages\IJourn
 	 *
 	 * @return string
 	 */
-	protected function formatKey($key, $suffix = NULL)
+	public function formatKey($key, $suffix = NULL): string
 	{
 		return self::NS_NETTE . ':' . $key . ($suffix ? ':' . $suffix : NULL);
+	}
+
+
+	public function lock(string $key): void
+	{
+		$this->client->lock($this->formatKey($key));
+	}
+
+
+	public function unlock(string $key): void
+	{
+		$this->client->unlock($this->formatKey($key));
 	}
 
 }

--- a/src/Kdyby/Redis/RedisStorage.php
+++ b/src/Kdyby/Redis/RedisStorage.php
@@ -45,7 +45,7 @@ class RedisStorage extends Nette\Object implements IMultiReadStorage
 	private $client;
 
 	/**
-	 * @var \Nette\Caching\Storages\IJournal
+	 * @var \Nette\Caching\Storages\IJournal|\Kdyby\Redis\RedisJournal
 	 */
 	private $journal;
 
@@ -224,6 +224,14 @@ class RedisStorage extends Nette\Object implements IMultiReadStorage
 			if (!$this->journal) {
 				throw new Nette\InvalidStateException('CacheJournal has not been provided.');
 			}
+
+			$this->journal->lock($cacheKey);
+			if (isset($dp[Cache::TAGS])) {
+				foreach ($dp[Cache::TAGS] as $tag) {
+					$this->journal->lock($tag);
+				}
+			}
+
 			$this->journal->write($cacheKey, $dp);
 		}
 
@@ -243,6 +251,13 @@ class RedisStorage extends Nette\Object implements IMultiReadStorage
 			}
 
 			$this->unlock($key);
+
+			$this->journal->unlock($cacheKey);
+			if (isset($dp[Cache::TAGS])) {
+				foreach ($dp[Cache::TAGS] as $tag) {
+					$this->journal->unlock($tag);
+				}
+			}
 
 		} catch (RedisClientException $e) {
 			$this->remove($key);

--- a/tests/KdybyTests/Redis/RedisJournalLock.phpt
+++ b/tests/KdybyTests/Redis/RedisJournalLock.phpt
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Test: \Kdyby\Redis\RedisStorage.
+ *
+ * @testCase \Kdyby\Redis\RedisJournalLock
+ * @author Václav Čevela <spamer@spameri.cz>
+ * @package Kdyby\Redis
+ */
+
+namespace KdybyTests\Redis;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+
+
+/**
+ * @author Václav Čevela <spamer@spameri.cz>
+ */
+class RedisJournalLock extends AbstractRedisTestCase
+{
+
+	/**
+	 * @var \Kdyby\Redis\RedisJournal
+	 */
+	public $journal;
+
+	/**
+	 * @var \Kdyby\Redis\RedisStorage
+	 */
+	private $storage;
+
+
+
+	public function setUp()
+	{
+		parent::setUp();
+		$this->journal = new \Kdyby\Redis\RedisJournal($this->client);
+		$this->storage = new \Kdyby\Redis\RedisStorage(
+			$this->client,
+			$this->journal
+		);
+	}
+
+
+
+	/**
+	 * key and data with special chars
+	 *
+	 * @return array
+	 */
+	public function basicData()
+	{
+		return [
+			$key = [1, TRUE],
+			$value = range("\x00", "\xFF"),
+		];
+	}
+
+
+
+	public function testBasics()
+	{
+		list($key, $value) = $this->basicData();
+
+		$cache = new \Nette\Caching\Cache(
+			$this->storage
+		);
+		\Tester\Assert::null($cache->load($key), "Cache content");
+
+		// Writing cache...
+		$cache->save($key, $value);
+		\Tester\Assert::same($value, $cache->load($key), "Is cache ok?");
+
+		// Removing from cache using unset()...
+		$cache->remove($key);
+		\Tester\Assert::false($cache->load($key) !== NULL, "Is cached?");
+
+		// Removing from cache using set NULL...
+		$cache->save($key, $value);
+		$cache->save($key, NULL);
+		\Tester\Assert::false($cache->load($key) !== NULL, "Is cached?");
+	}
+
+	public function testJournalLocked()
+	{
+		list($key, $value) = $this->basicData();
+
+		$cache = new \Nette\Caching\Cache(
+			$this->storage
+		);
+
+		$this->journal->lock('Test-T4G');
+		$cache->save($key, $value, [
+			\Nette\Caching\Cache::TAGS => [
+				'Test-T4G'
+			]
+		]);
+
+		\Tester\Assert::false($cache->load('Test-T4G') !== NULL, 'Is cached?');
+	}
+
+
+	/**
+	 * @param mixed $val
+	 * @return mixed
+	 */
+	public static function dependency($val)
+	{
+		return $val;
+	}
+
+
+}
+
+\run(new RedisJournalLock());


### PR DESCRIPTION
Problem: 
Data storaged in redis does not have locks and locks lose their associated data.

Implemented:
- TTL to all locks stored in redis.
- Locking redis journal.
- Prevents missmatched data and locks.